### PR TITLE
Push PR branch images without updating `latest` tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,12 @@ jobs:
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: markb/burmis-ubuntu-dev
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
@@ -39,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v2.4.0
         with:
           push: true
-          tags: markb/burmis-ubuntu-dev:latest
+          tags: ${{ steps.meta.outputs.tags }}
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
I probably don't actually need to push these to Docker Hub at all but it might still be useful during development.

I might want to find a way to delete these on a scheduled basis.